### PR TITLE
fix: using null as an array offset is deprecated, use an empty string…

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -22246,6 +22246,11 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 						// pagebreak-after is mapped to pagebreak-before on i+1 in Tags/Tr.php
 						$pagebreaklookahead++;
 					}
+					// corner case: if the pagelookahead is bigger than the pagesize, we break anyway, so fill up the page
+					if ($pagebreaklookahead * $maxrowheight + $extra > $pagetrigger + 0.001) {
+						$pagebreaklookahead = 1;
+					}
+					// if we exceed page boundaries: restart table on next page before printing the line
 					if ($j == $startcol && ((($y + $pagebreaklookahead * $maxrowheight + $extra ) > ($pagetrigger + 0.001)) || (($this->keepColumns || !$this->ColActive) && !empty($tablefooter) && ($y + $maxrowheight + $tablefooterrowheight + $extra) > $pagetrigger) && ($this->tableLevel == 1 && $i < ($numrows - $table['headernrows']))) && ($y0 > 0 || $x0 > 0) && !$this->InFooter && $this->autoPageBreak) {
 						if (!$skippage) {
 							$finalSpread = true;

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -610,7 +610,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 	var $directionality;
 
-	var $extgstates; // Used for alpha channel - Transparency (Watermark)
+	var $extgstates = []; // Used for alpha channel - Transparency (Watermark)
 	var $mgl;
 	var $mgt;
 	var $mgr;

--- a/src/SizeConverter.php
+++ b/src/SizeConverter.php
@@ -70,6 +70,7 @@ class SizeConverter implements \Psr\Log\LoggerAwareInterface
 				break;
 
 			case '%':
+			case '%%': // Issue2051
 				if ($fontsize && $usefontsize) {
 					$size *= $fontsize / 100;
 				} else {

--- a/src/Writer/FontWriter.php
+++ b/src/Writer/FontWriter.php
@@ -162,10 +162,16 @@ class FontWriter
 				$ssfaid = 'AA';
 				$ttf = new TTFontFile($this->fontCache, $this->fontDescriptor);
 				$subsetCount = count($font['subsetfontids']);
+
 				for ($sfid = 0; $sfid < $subsetCount; $sfid++) {
 					$this->mpdf->fonts[$k]['n'][$sfid] = $this->mpdf->n + 1;  // NB an array for subset
 					$subsetname = 'MPDF' . $ssfaid . '+' . $font['name'];
-					$ssfaid++;
+
+					if (function_exists('str_increment')) {
+						$ssfaid = str_increment($ssfaid);
+					} else {
+						$ssfaid++;
+					}
 
 					/* For some strange reason a subset ($sfid > 0) containing less than 97 characters causes an error
 					  so fill up the array */

--- a/tests/Issues/Issue2013Test.php
+++ b/tests/Issues/Issue2013Test.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Issues;
+
+class Issue2013Test extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
+{
+
+	public function testPdfTableBreakAvoidTooMuch()
+	{
+		// test case: spill items that take about a bit more than half a page, no page-break-avoid would fit them on two pages, with page-break it will be three
+		$mpdf = new \Mpdf\Mpdf();
+		$html = '';
+		$itemsPerTwothirdsPage = 28;
+		for ($i = 0; $i < 5*$itemsPerTwothirdsPage; $i++) {
+			$html .= '<tr style="page-break-before: avoid; background: lime;"><td>content</td></tr>';
+		}
+		$mpdf->WriteHTML('<html><body><h1>Test</h1>
+		<table>'.$html.'</table>
+		</html>');
+
+		// without the bugfix, it would produce 98 pages, with the bugfix: 7
+		$this->assertEquals($mpdf->page, 7);
+	}
+
+}

--- a/tests/Issues/Issue2051Test.php
+++ b/tests/Issues/Issue2051Test.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Issues;
+
+class Issue2051Test extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
+{
+
+	public function testPdfWithDoublePercent()
+	{
+		// test case: spill items that take about a bit more than half a page, no page-break-avoid would fit them on two pages, with page-break it will be three
+		$mpdf = new \Mpdf\Mpdf();
+		$html = '';
+		for ($i = 0; $i < 10; $i++) {
+			$html .= 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.';
+		}
+		$mpdf->WriteHTML('<html><body><h1>Test</h1>
+		<div style="width: 100%%;">'.$html.'</div>
+		</html>');
+
+		// without the bugfix, it would produce 10 pages, with the bugfix: 2
+		$this->assertEquals($mpdf->page, 2);
+	}
+
+}

--- a/tests/Mpdf/Image/SvgTest.php
+++ b/tests/Mpdf/Image/SvgTest.php
@@ -27,9 +27,7 @@ class SvgTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 	{
 		parent::set_up();
 
-		$mpdf = Mockery::mock(Mpdf::class);
-
-		$mpdf->shouldIgnoreMissing();
+		$mpdf = new \Mpdf\Mpdf();
 
 		$mpdf->img_dpi = 72;
 		$mpdf->PDFAXwarnings = [];


### PR DESCRIPTION
… instead

<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
Explain what you have changed, and why.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
